### PR TITLE
Open serial port with serial.serial_for_url to be able to use pyserial's URL handlers

### DIFF
--- a/pyprofibus/phy_serial.py
+++ b/pyprofibus/phy_serial.py
@@ -64,10 +64,9 @@ class CpPhySerial(CpPhy):
 					raise PhyError("Module serial.rs485 "
 						"is not available. "
 						"Please use useRS485Class=False.")
-				self.__serial = serial.rs485.RS485()
+				self.__serial = serial.rs485.RS485(port)
 			else:
-				self.__serial = serial.Serial()
-			self.__serial.port = port
+				self.__serial = serial.serial_for_url(port, do_not_open = True)
 			self.__serial.baudrate = CpPhy.BAUD_9600
 			self.__serial.bytesize = 8
 			self.__serial.parity = serial.PARITY_EVEN


### PR DESCRIPTION
Hello,
I made a very minor change which allowed me to establish communication with a Lakeshore 240 module via an RS485-to-Ethernet converter using pyserial's URL handlers.

However, after a single data exchange the communication is aborted with the message "Terminating: Service not active on slave 10":
```
GSD parser warning in 'LSCI0F84.gsd' at line 18:
Info_Text                  = "GSD Version 1.0, valid for the Model 240-2P and 240-8P"
 --> Ignored unknown line
GSD parser warning in 'LSCI0F84.gsd' at line 23:
FMS_supp                   = 0
 --> Ignored unknown line
GSD parser warning in 'LSCI0F84.gsd' at line 31:
31.25_supp                 = 0
 --> Ignored unknown line
GSD parser warning in 'LSCI0F84.gsd' at line 92:
1
 --> Ignored unknown line
DPM2: Trying to initialize slave 10...
PHY-serial: TX   10 0A 02 49 55 16
PHY-serial: TX   10 0A 02 49 55 16
PHY-serial: RX   10 02 0A 00 0C 16
DPM2: slave[0A].state --> 'Wait for diag'
DPM2: Requesting Slave_Diag from slave 10...
PHY-serial: TX   68 05 05 68 8A 82 6D 3C 3E F3 16
PHY-serial: RX   68 0B 0B 68 82 8A 08 3E 3C 06 05 00 FF 0F 84 2B 16
DPM2: slave[0A].state --> 'Wait for Prm'
DPM2: Sending Set_Prm to slave 10...
PHY-serial: TX   68 0C 0C 68 8A 82 5D 3D 3E 80 01 01 00 0F 84 01 FA 16
PHY-serial: RX   E5
DPM2: slave[0A].state --> 'Wait for Cfg'
DPM2: Sending Chk_Cfg to slave 10...
PHY-serial: TX   68 0D 0D 68 8A 82 7D 3E 3E 93 93 93 93 93 93 93 93 9D 16
PHY-serial: RX   E5
PHY-serial: TX   68 0D 0D 68 8A 82 5D 3E 3E 93 93 93 93 93 93 93 93 7D 16
DPM2: slave[0A].state --> 'Request diag and wait for DX-ready'
DPM2: Requesting Slave_Diag (WDXRDY) from slave 10...
PHY-serial: RX   E5
PHY-serial: TX   68 05 05 68 8A 82 5D 3C 3E E3 16
PHY-serial: RX   68 0B 0B 68 82 8A 08 3E 3C 00 04 00 02 0F 84 27 16
DPM2: slave[0A].state --> 'Data_Exchange'
DPM2: Initialization finished. Running Data_Exchange with slave 10...
PHY-serial: TX   68 06 06 68 0A 02 7D 00 00 00 89 16
PHY-serial: RX   68 23 23 68 02 0A 08 43 92 E7 D1 43 92 30 59 00 00 00 00 43 92 95 40 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 A9 16
PHY-serial: TX   68 06 06 68 0A 02 5D 00 00 00 69 16
PHY-serial: RX   10 02 0A 03 0F 16
Terminating: Service not active on slave 10
``` 

I can circumvent this by setting diag_period=1, which ends up reporting an error in the configuration and reinitializes the communication after every data exchange:
```
...
DPM1: slave[0A].state --> 'Data_Exchange'
DPM1: Initialization finished. Running Data_Exchange with slave 10...
PHY-serial: TX   68 06 06 68 0A 02 7D 00 00 00 89 16
PHY-serial: RX   68 23 23 68 02 0A 08 43 92 E7 47 43 92 2F C0 00 00 00 00 43 92 96 72 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 B8 16
DPM1: slave[0A].state --> 'Request diag and wait for DX-ready'
DPM1: Requesting Slave_Diag (WDXRDY) from slave 10...
PHY-serial: TX   68 05 05 68 8A 82 5D 3C 3E E3 16
PHY-serial: RX   68 0B 0B 68 82 8A 08 3E 3C 06 05 00 FF 0F 84 2B 16
DPM1:  >ERROR<  Slave 10 reports a faulty configuration (Chk_Cfg).
DPM1: Slave 10 requests a new parameterization (Set_Prm).
DPM1: slave[0A].state --> 'Init'
DPM1: Trying to initialize slave 10...
...
``` 

I was hoping you might have any suggestions what is going wrong. The GSD file is available [here](https://www.lakeshore.com/docs/default-source/default-document-library/240seriesgsd.zip?sfvrsn=7ede6b12_3). The conf file is below. I just send a small number of zero bytes (in this case three) as out data. I did encounter the same issue with a RS485-to-USB adapter, so it doesn't seem to be an issue with the Ethernet communication.
```
[PROFIBUS]
debug=2

[PHY]
type=serial
dev=socket://169.254.52.94:32
rtscts=False
dsrdtr=False
spiBus=0
spiCS=0
spiSpeedHz=2500000
baud=9600

[FDL]

[DP]
master_class=1
master_addr=2

[SLAVE_0]
name=ls240
addr=10
gsd=LSCI0F84.gsd
sync_mode=0
freeze_mode=0
group_mask=1
watchdog_ms=0
module_0=Sensor Reading 1
module_1=Sensor Reading 2
module_2=Sensor Reading 3
module_3=Sensor Reading 4
module_4=Sensor Reading 5
module_5=Sensor Reading 6
module_6=Sensor Reading 7
module_7=Sensor Reading 8
output_size=32
input_size=3
diag_period=1

``` 

Thank you!